### PR TITLE
Improve Blog Item Headings on Blog View

### DIFF
--- a/collective/blog/view/default_item.pt
+++ b/collective/blog/view/default_item.pt
@@ -28,7 +28,7 @@
  <!-- In Plone 4 we instead use the content-core macro -->
   <tal:plone4 condition="python:body_macro is None" on-error="python: errors.append(True)">
     <div tal:replace="structure provider:plone.abovecontenttitle" />
-    <h2 class="documentFirstHeading"><metal:field use-macro="python:here.widget('title', mode='view')" /></h2>
+    <h2 class="blogItemHeading"><metal:field use-macro="python:here.widget('title', mode='view')" /></h2>
     <div tal:replace="structure provider:plone.belowcontenttitle" />
     <div class="documentDescription"><metal:field use-macro="python:here.widget('description', mode='view')" /></div>
     <div tal:replace="structure provider:plone.abovecontentbody" />
@@ -39,7 +39,7 @@
   <!-- If macro display fails, we fall back to only showing a "Read more..." link -->
   <tal:on-error condition="errors">
     <div tal:replace="structure provider:plone.abovecontenttitle" />
-    <h2 class="documentFirstHeading"><metal:field use-macro="python:here.widget('title', mode='view')" /></h2>
+    <h2 class="blogItemHeading"><metal:field use-macro="python:here.widget('title', mode='view')" /></h2>
     <div tal:replace="structure provider:plone.belowcontenttitle" />
     <div class="documentDescription"><metal:field use-macro="python:here.widget('description', mode='view')" /></div>
     <div tal:replace="structure provider:plone.abovecontentbody" />

--- a/collective/blog/view/default_item.pt
+++ b/collective/blog/view/default_item.pt
@@ -28,7 +28,7 @@
  <!-- In Plone 4 we instead use the content-core macro -->
   <tal:plone4 condition="python:body_macro is None" on-error="python: errors.append(True)">
     <div tal:replace="structure provider:plone.abovecontenttitle" />
-    <h1 class="documentFirstHeading"><metal:field use-macro="python:here.widget('title', mode='view')" /></h1>
+    <h2 class="documentFirstHeading"><metal:field use-macro="python:here.widget('title', mode='view')" /></h2>
     <div tal:replace="structure provider:plone.belowcontenttitle" />
     <div class="documentDescription"><metal:field use-macro="python:here.widget('description', mode='view')" /></div>
     <div tal:replace="structure provider:plone.abovecontentbody" />
@@ -39,7 +39,7 @@
   <!-- If macro display fails, we fall back to only showing a "Read more..." link -->
   <tal:on-error condition="errors">
     <div tal:replace="structure provider:plone.abovecontenttitle" />
-    <h1 class="documentFirstHeading"><metal:field use-macro="python:here.widget('title', mode='view')" /></h1>
+    <h2 class="documentFirstHeading"><metal:field use-macro="python:here.widget('title', mode='view')" /></h2>
     <div tal:replace="structure provider:plone.belowcontenttitle" />
     <div class="documentDescription"><metal:field use-macro="python:here.widget('description', mode='view')" /></div>
     <div tal:replace="structure provider:plone.abovecontentbody" />

--- a/collective/blog/view/default_item.py
+++ b/collective/blog/view/default_item.py
@@ -3,20 +3,20 @@ from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 import re
 
-START_RE = re.compile('<h1[^<>]+documentFirstHeading[^<>]+>') # Standard plone header
-END_RE = re.compile('</h1>')
+START_RE = re.compile('<h2[^<>]+documentFirstHeading[^<>]+>') # Standard plone header
+END_RE = re.compile('</h2>')
 
 class DefaultItemView(BrowserView):
     """
     The default blog item view
     """
-    
+
     template = ViewPageTemplateFile("default_item.pt")
-    
+
     def __init__(self, context, request):
         self.context = context
         self.request = request
-    
+
     def __call__(self):
         html = self.template()
         tag = START_RE.search(html)

--- a/collective/blog/view/default_item.py
+++ b/collective/blog/view/default_item.py
@@ -3,7 +3,7 @@ from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 import re
 
-START_RE = re.compile('<h2[^<>]+documentFirstHeading[^<>]+>') # Standard plone header
+START_RE = re.compile('<h2[^<>]+blogItemHeading[^<>]+>') # Standard plone header
 END_RE = re.compile('</h2>')
 
 class DefaultItemView(BrowserView):


### PR DESCRIPTION
SEO best practice allows only one `<h1>` element per page.

Also, giving them the `documentFirstHeading` class doesn't make a lot of sense when they aren't first in the document, and will probably mess up most diazo themes.
